### PR TITLE
5933 - update view links

### DIFF
--- a/src/components/ViewDetails.jsx
+++ b/src/components/ViewDetails.jsx
@@ -25,7 +25,8 @@ function viewInfo(data, appId, metadata) {
   const sceneName = arraySearch("key", "name", sceneKey, metadata.scenes);
   const accountSlug = metadata.account.slug;
   const appSlug = metadata.slug;
-  const builderUrl = `https://builder.knack.com/${accountSlug}/${appSlug}#pages/${sceneKey}/views/${data.key}`
+  const builderUrl = `https://builder.knack.com/${accountSlug}/${appSlug}/pages/${sceneKey}/views/${data.key}/${data.type}`
+  console.log(builderUrl)
 
   return (
     <Row>

--- a/src/components/ViewDetails.jsx
+++ b/src/components/ViewDetails.jsx
@@ -26,7 +26,6 @@ function viewInfo(data, appId, metadata) {
   const accountSlug = metadata.account.slug;
   const appSlug = metadata.slug;
   const builderUrl = `https://builder.knack.com/${accountSlug}/${appSlug}/pages/${sceneKey}/views/${data.key}/${data.type}`
-  console.log(builderUrl)
 
   return (
     <Row>


### PR DESCRIPTION
Fixes https://github.com/cityofaustin/atd-data-tech/issues/5933

After the switch to the new Knack builder, the urls for views changed

https://knack-explorer.austinmobility.io/5815f29f7f7252cc2ca91c4f/views/view_1563 
clicking the url https://builder.knack.com/atd/amd#pages/scene_568/views/view_1563 redirects to which is the schema list

this PR changes the link to be: https://builder.knack.com/atd/amd/pages/scene_568/views/view_1563/table 
deployed link: https://deploy-preview-15--knack-explorer.netlify.app/5815f29f7f7252cc2ca91c4f/views/view_1563