### PR TITLE
Fix Typo: SOrt => Sort

### DIFF
--- a/src/components/ObjectDetails.jsx
+++ b/src/components/ObjectDetails.jsx
@@ -60,7 +60,7 @@ function objInfo(data) {
               <td>{JSON.stringify(data.inflections)}</td>
             </tr>
             <tr>
-              <td>SOrt</td>
+              <td>Sort</td>
               <td>{JSON.stringify(data.sort)}</td>
             </tr>
             <tr>


### PR DESCRIPTION
This is the most minor of minor things -- fixing a typo in the Knack Explorer. I noticed this today working on this issue: https://github.com/cityofaustin/atd-data-tech/issues/15878.  